### PR TITLE
LA: don't delete lines of unaffected regions on delected_scheme=lines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <name>CITlabModule</name>
     <groupId>de.uros.citlab</groupId>
     <artifactId>module</artifactId>
-    <version>2.6.3</version>
+    <version>2.6.4-SNAPSHOT</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>de.uros.citlab</groupId>

--- a/src/main/java/de/uros/citlab/module/la/LayoutAnalysisURO_ML.java
+++ b/src/main/java/de/uros/citlab/module/la/LayoutAnalysisURO_ML.java
@@ -155,7 +155,7 @@ public class LayoutAnalysisURO_ML implements ILayoutAnalysis, Serializable {
                         if (PageXmlUtil.isT2ITextRegion(aTextReg, xmlFile)) {
                             continue;
                         }
-                        if (ids != null && ArrayUtil.linearSearch(ids, aTextReg.getId()) >= 0) {
+                        if (ids != null && ArrayUtil.linearSearch(ids, aTextReg.getId()) < 0) {
                         	continue;
                         }
                         List<TextLineType> textLine = aTextReg.getTextLine();

--- a/src/main/java/de/uros/citlab/module/la/LayoutAnalysisURO_ML.java
+++ b/src/main/java/de/uros/citlab/module/la/LayoutAnalysisURO_ML.java
@@ -155,6 +155,9 @@ public class LayoutAnalysisURO_ML implements ILayoutAnalysis, Serializable {
                         if (PageXmlUtil.isT2ITextRegion(aTextReg, xmlFile)) {
                             continue;
                         }
+                        if (ids != null && ArrayUtil.linearSearch(ids, aTextReg.getId()) >= 0) {
+                        	continue;
+                        }
                         List<TextLineType> textLine = aTextReg.getTextLine();
                         if (!textLine.isEmpty()) {
                             LOG.debug("delete " + textLine.size() + " text lines in TextRegion " + aTextReg.getId());

--- a/src/main/java/de/uros/citlab/module/util/MetadataUtil.java
+++ b/src/main/java/de/uros/citlab/module/util/MetadataUtil.java
@@ -39,7 +39,7 @@ public class MetadataUtil {
     }
 
     public static String getSoftwareVersion() {
-        return "2.6.2";
+        return "2.6.3";
     }
 
 }

--- a/src/main/java/de/uros/citlab/module/util/MetadataUtil.java
+++ b/src/main/java/de/uros/citlab/module/util/MetadataUtil.java
@@ -39,7 +39,7 @@ public class MetadataUtil {
     }
 
     public static String getSoftwareVersion() {
-        return "2.6.3";
+        return "2.6.4-SNAPSHOT";
     }
 
 }


### PR DESCRIPTION
In Layout Analysis, when region IDs are given and delete_scheme = lines, only delete lines of the given regions.
I committed the change to the develop branch and changed the current version number to 2.6.4-SNAPSHOT.