### PR TITLE
Bugfix htr cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <name>CITlabModule</name>
     <groupId>de.uros.citlab</groupId>
     <artifactId>module</artifactId>
-    <version>2.6.6-SNAPSHOT</version>
+    <version>2.6.6</version>
     <packaging>jar</packaging>
     <parent>
         <groupId>de.uros.citlab</groupId>

--- a/src/main/java/de/uros/citlab/module/htr/HTRParser.java
+++ b/src/main/java/de/uros/citlab/module/htr/HTRParser.java
@@ -215,12 +215,13 @@ public class HTRParser implements IHtrCITlab {
     }
 
     public HTR getHTR(String om, String lm, String cm, String storageDir, String[] props) {
-        HTR htrDummy = new HTR(om, lm, cm, props);
+    	String[] htrProps = HTRParserPlus.extractHtrProperties(props);
+        HTR htrDummy = new HTR(om, lm, cm, htrProps);
         int hash = htrDummy.hashCode();
         if (!htrs.containsKey(hash)) {
             ISNetwork network = getNetwork(om, cm);
-            ILangMod langMod = getLangMod(om, lm, network.getCharMap(), props);
-            htrs.put(hash, new HTR(network, langMod, om, lm, cm, props));
+            ILangMod langMod = getLangMod(om, lm, network.getCharMap(), htrProps);
+            htrs.put(hash, new HTR(network, langMod, om, lm, cm, htrProps));
         }
         HTR res = htrs.get(hash);
         if (storageDir == null || storageDir.isEmpty()) {

--- a/src/main/java/de/uros/citlab/module/htr/HTRParserPlus.java
+++ b/src/main/java/de/uros/citlab/module/htr/HTRParserPlus.java
@@ -207,7 +207,7 @@ public class HTRParserPlus extends Observable implements IHtrCITlab {
 //            textEquivType.setConf(new Float(result.getSecond()));
                 LOG.info("decoded '" + result + "' for textline " + textLine.getId() + " with" + (htr.isLM(props) ? "out" : "") + " language model .");
             } catch (RuntimeException ex) {
-                notifyObservers(new ErrorNotification(xmlFile, lineImage.getTextLine().getId(), ex, TrainHtrPlus.class));
+                notifyObservers(new ErrorNotification(xmlFile, lineImage.getTextLine().getId(), ex, HTRParserPlus.class));
 //                PageXmlUtil.deleteCustomTags(textLine, ReadingOrderTag.TAG_NAME);
 //                PageXmlUtil.setTextEquiv(textLine, "");
             } catch (OutOfMemoryError ex) {
@@ -215,7 +215,7 @@ public class HTRParserPlus extends Observable implements IHtrCITlab {
                 LOG.error("OutOfMemoryError image=" + imgPath + " lineid=" + textLine.getId());
                 SysResourcesUtil.logMemUsage(LOG, Level.ERROR, true);
                 System.gc();
-                notifyObservers(new ErrorNotification(xmlFile, lineImage.getTextLine().getId(), ex, TrainHtrPlus.class));
+                notifyObservers(new ErrorNotification(xmlFile, lineImage.getTextLine().getId(), ex, HTRParserPlus.class));
 //                PageXmlUtil.deleteCustomTags(textLine, ReadingOrderTag.TAG_NAME);
 //                PageXmlUtil.setTextEquiv(textLine, "");
             }

--- a/src/main/java/de/uros/citlab/module/htr/HTRParserPlus.java
+++ b/src/main/java/de/uros/citlab/module/htr/HTRParserPlus.java
@@ -153,7 +153,7 @@ public class HTRParserPlus extends Observable implements IHtrCITlab {
 
     /**
 	 * Create a copy of the properties without entries regarding the page to be processed, e.g. the ConfMat container output filename.
-	 * Not removing it will cause a {@link htrs} cache entry for each page processed with this parser instance, as it will affect the hashCode used as key in the map.
+	 * Not removing it will cause a {@link #htrs} cache entry for each page processed with this parser instance, as it will affect the hashCode used as key in the map.
      * @param props
      * @return
      */

--- a/src/main/java/de/uros/citlab/module/la/LayoutAnalysisURO_ML.java
+++ b/src/main/java/de/uros/citlab/module/la/LayoutAnalysisURO_ML.java
@@ -33,6 +33,8 @@ import java.util.*;
  * @author tobi
  */
 public class LayoutAnalysisURO_ML implements ILayoutAnalysis, Serializable {
+	
+	public static final boolean ENABLE_T2I_REGIONS = false;
 
     private static final long serialVersionUID = 1L;
     private static final Logger LOG = LoggerFactory.getLogger(LayoutAnalysisURO_ML.class.getName());
@@ -125,10 +127,14 @@ public class LayoutAnalysisURO_ML implements ILayoutAnalysis, Serializable {
         PageType page = xmlFile.getPage();
         List<TrpRegionType> globRegs = page.getTextRegionOrImageRegionOrLineDrawingRegion();
         List<TextRegionType> globTextRegs = PageXmlUtils.getTextRegions(xmlFile);
-        TextRegionType t2ITextRegion = PageXmlUtil.getT2ITextRegion(globTextRegs, xmlFile);
-        if (t2ITextRegion != null) {
-            globRegs.remove(t2ITextRegion);
-            globTextRegs.remove(t2ITextRegion);
+        
+        TextRegionType t2ITextRegion = null;
+        if (ENABLE_T2I_REGIONS) {
+	        t2ITextRegion = PageXmlUtil.getT2ITextRegion(globTextRegs, xmlFile);
+	        if (t2ITextRegion != null) {
+	            globRegs.remove(t2ITextRegion);
+	            globTextRegs.remove(t2ITextRegion);
+	        }
         }
 //        List<TextRegionType> globTextRegs = PageXmlUtils.getTextRegions(xmlFile);
         String deleteScheme = PropertyUtil.getProperty(propCur, Key.LA_DELETESCHEME);
@@ -152,9 +158,11 @@ public class LayoutAnalysisURO_ML implements ILayoutAnalysis, Serializable {
                 case DEL_LINES:
                     //If Flag is set, delete all TextLines in given TextRegions
                     for (TextRegionType aTextReg : globTextRegs) {
-                        if (PageXmlUtil.isT2ITextRegion(aTextReg, xmlFile)) {
-                            continue;
-                        }
+                    	if (ENABLE_T2I_REGIONS) {
+	                        if (PageXmlUtil.isT2ITextRegion(aTextReg, xmlFile)) {
+	                            continue;
+	                        }
+                    	}
                         if (ids != null && ArrayUtil.linearSearch(ids, aTextReg.getId()) < 0) {
                         	continue;
                         }

--- a/src/main/java/de/uros/citlab/module/types/Key.java
+++ b/src/main/java/de/uros/citlab/module/types/Key.java
@@ -68,7 +68,7 @@ public class Key {
     /**
      * if Value is set, save htr ConfMatContainer to this file name (instead of container.bin)
      */
-    public static final String HTR_CONFMAT_CONTAINER_FILENAME ="";
+    public static final String HTR_CONFMAT_CONTAINER_FILENAME ="ConfMatOutFilename";
 
     /**
      * path to a temporal folder which is used to save temporarily important

--- a/src/test/java/de/uros/citlab/module/htr/HTRParserPlusTest.java
+++ b/src/test/java/de/uros/citlab/module/htr/HTRParserPlusTest.java
@@ -1,0 +1,56 @@
+package de.uros.citlab.module.htr;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.FilenameUtils;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.uros.citlab.module.htr.HTRParserPlus;
+import de.uros.citlab.module.kws.ConfMatContainer;
+import de.uros.citlab.module.types.HTR;
+import de.uros.citlab.module.types.Key;
+import de.uros.citlab.module.util.PropertyUtil;
+import org.junit.Assert;
+
+public class HTRParserPlusTest {
+	private static final Logger LOG = LoggerFactory.getLogger(HTRParserPlusTest.class);
+	
+	/**
+	 * Test for the fix of https://github.com/Transkribus/TranskribusAppServerModules/issues/76
+	 * <br><br>
+	 * HTR was cached for each processed page as the confmat container filename property was taken into account for the hashCode i.e. key in the HTR cache map.
+	 * This caused the cache grow unnecessarily and made the HTR crash with OutOfMemoryError, especially if a ILangMod was included.
+	 */
+	@Test 
+	public void testExtractHtrProperties() {
+		final String om = "/path/to/HTR";
+		final String lm = "/path/to/dict.dict";
+		final String cm = "/path/to/HTR" + Key.GLOBAL_CHARMAP;
+		String[] props = new String[] {"mySpecialParam", "DO NOT TOUCH"};
+		
+		final HashMap<Integer, HTR> htrs = new HashMap<>();
+		
+		for(int i = 0; i < 10; i++) {
+			final String confMatFileName = FilenameUtils.getBaseName(ConfMatContainer.CONFMAT_CONTAINER_FILENAME)
+					+ "_" + i + "." + FilenameUtils.getExtension(ConfMatContainer.CONFMAT_CONTAINER_FILENAME);
+			props = PropertyUtil.setProperty(props, Key.HTR_CONFMAT_CONTAINER_FILENAME, confMatFileName);
+		
+			//remove the Confmat filename as we do not want that in the HTR cache
+			String[] htrProps = HTRParserPlus.extractHtrProperties(props);
+			LOG.info("Initial props after extraction: {}", Arrays.stream(props).collect(Collectors.joining(", ", "[ ", " ]")));
+			
+			//this is the caching mechanism's code from HTRParser(Plus)
+			HTR htrDummy = new HTR(om, lm, cm, htrProps);
+			int hash = htrDummy.hashCode();
+	        if (!htrs.containsKey(hash)) {
+	        	htrs.put(hash, htrDummy);
+	        }
+		}
+		Assert.assertEquals("HTR cache contains the same HTR multiple times!", 1, htrs.size());
+		LOG.info("HTR cache size = {}", htrs.size());
+	}
+}


### PR DESCRIPTION
Caused OutOfMemoryErrors when setting custom ConfMat container filenames for each page.

see Transkribus/TranskribusAppServerModules#76

Referenced in Transkribus as CITlabModule 2.6.6